### PR TITLE
Use http.request instead of http.createClient

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,9 +22,14 @@ class ScopedClient
 
       port   = @options.port || 
                  ScopedClient.defaultPort[@options.protocol] || 80
-      client = http.createClient port, @options.hostname
-      req    = client.request method, @fullPath(), headers
-  
+
+      req = http.request
+        port:    port
+        host:    @options.hostname
+        method:  method
+        path:    @fullPath()
+        headers: headers
+
       req.write reqBody, 'utf-8' if sendingData
       callback null, req if callback
     catch err


### PR DESCRIPTION
http.createClient appears to be deprecated. It's not documented in the v0.4.10 docs at least. We thought this may have been causing connections to leak but that seems not to be the case. Still, thought you might want to come up to the latest node version.
