### PR TITLE
Remove callback on 'close' event

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -34,7 +34,6 @@ class ScopedClient
         agent:   false
       )
       if callback
-        req.on 'close', callback
         req.on 'error', callback
       req.write reqBody, 'utf-8' if sendingData
       callback null, req if callback


### PR DESCRIPTION
The user-provided callback was being invoked on the `'close`' event, which doesn't seem necessary. Removing this [gets the tests passing](http://travis-ci.org/iangreenleaf/node-scoped-http-client) on node 0.6.
