### PR TITLE
HTTP_PROXY support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   { "install": "make js"
 ,   "test": "make test"
   }
+, "dependencies":
+  { "tunnel": "0.0.2"
+  }
 , "devDependencies":
   { "coffee-script": "1.3.3"
   }


### PR DESCRIPTION
First of all, not expecting you to actually merge this pull request as is.  Just wanted to get eyes on it.
1.  Do you think proxies should be supported by scoped-http-client?  I'm trying to get hubot to use a proxy and this seemed like the best way to me.
2.  No tests yet.  Do you think testing the HTTP_PROXY regex is sufficient or do you want to see validation against an actual request?
3.  Can the fullPath() function be modified to include protocol or host or should I stick with the way I constructed the request path parameter?

Thanks,
Shawn
