### PR TITLE
Support adding a basic timeout to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ client.get(function (err, req) {
 })
 ```
 
+Adding simple timeout support:
+
+	client = ScopedClient.create('http://10.255.255.1:9999');
+
+	client.timeout(100);
+
+	client.get()(function(err, resp, body) {
+	  if (err) {
+	    util.puts("ERROR: " + err);
+	   }
+	});
+
+
 ## Development
 
 Run this in the main directory to compile coffeescript to javascript as you go:

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -34,6 +34,10 @@ class ScopedClient
         headers: headers
         agent:   @options.agent or false
       )
+      if @options.timeout
+        req.setTimeout @options.timeout, () ->
+          req.abort()
+
       if callback
         req.on 'error', callback
       req.write reqBody, @options.encoding if sendingData
@@ -51,6 +55,8 @@ class ScopedClient
 
           res.on 'end', ->
             callback null, res, body
+        req.on 'error', (error) ->
+          callback error, null, null
 
       req.end()
       @
@@ -115,6 +121,10 @@ class ScopedClient
     @
   encoding: (e = 'utf-8') ->
     @options.encoding = e
+    @
+
+  timeout: (time) ->
+    @options.timeout = time
     @
 
   auth: (user, pass) ->

--- a/test/timeout_test.coffee
+++ b/test/timeout_test.coffee
@@ -1,0 +1,13 @@
+ScopedClient = require '../lib'
+http         = require 'http'
+assert       = require 'assert'
+called       = 0
+
+client = ScopedClient.create 'http://10.255.255.1:9999'
+client.timeout 100
+
+client.get() (err, resp, body) ->
+  called++ if err
+
+process.on 'exit', ->
+  assert.equal 1, called


### PR DESCRIPTION
I wanted to resolve #13.  Open to other approaches etc as JavaScript is not my strongest language.
- If the timeout is trigger req.abort() is called.
- Also had to add an extra listener to ensure that the standard callback
  is called even if the connection ends in an error.

/cc @cmingxu, @drdamour
