### PR TITLE
Remove default value on the options.agent when not defined to stick to the behaviour of the Node#https.request

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -32,7 +32,7 @@ class ScopedClient
         method:  method
         path:    @fullPath()
         headers: headers
-        agent:   @options.agent or false
+        agent:   @options.agent
       )
       if callback
         req.on 'error', callback


### PR DESCRIPTION
According to the source code of node#https module, the behaviour for the request method changes when we pass an agent that is not undefined.

Taking a look on https://github.com/joyent/node/blob/master/lib/https.js#L110 , the method checks if options.agent is undefined to generate a client with the defaults.
Passing it as false will not provide the globalAgent to the request.

This commit remove the `or false` to stick to the same behaviour of the method.
