### PR TITLE
Added passthrough of options to node's http and https

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -6,7 +6,7 @@ qs   = require 'querystring'
 
 class ScopedClient
   # Those properties are in @options but they are either not passed to the request as options or some processing is made on them. They will not be added to the request's option param 
-  @nonPassThroughOptions = ['headers', 'hostname', 'encoding', 'auth', 'port', 'protocol', 'agent', 'query']
+  @nonPassThroughOptions = ['headers', 'hostname', 'encoding', 'auth', 'port', 'protocol', 'agent', 'query', 'host', 'path', 'pathname', 'slashes', 'hash']
   
   constructor: (url, options) ->
     @options = @buildOptions url, options
@@ -178,8 +178,9 @@ extend = (a, b) ->
 
 # Removes keys specified in second parameter from first parameter
 reduce = (a, b) ->
-  for key in b
-    delete a[key]
+  for propName in b
+    delete a[propName]
+  a
   
 exports.create = (url, options) ->
   new ScopedClient url, options


### PR DESCRIPTION
I think adding every options supported by node's http and https library is not the best approach. I suggest that options that are not handled internally by scoped-http-client are simply passed through to node's http/https objects.

I needed this to add options to ignore self signed ssl certificate on dev environments.
