### PR TITLE
Reraise exceptions within #request instead of continuing

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -74,6 +74,7 @@ class ScopedClient
       callback null, req if callback
     catch err
       callback err, req if callback
+      throw err
 
     (callback) =>
       if callback

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,60 +21,56 @@ class ScopedClient
       callback = reqBody
       reqBody  = null
 
-    try
-      headers      = extend {}, @options.headers
-      sendingData  = reqBody and reqBody.length > 0
-      headers.Host = @options.hostname
-      headers.Host += ":#{@options.port}" if @options.port
+    headers      = extend {}, @options.headers
+    sendingData  = reqBody and reqBody.length > 0
+    headers.Host = @options.hostname
+    headers.Host += ":#{@options.port}" if @options.port
 
-      # If `callback` is `undefined` it means the caller isn't going to stream
-      # the body of the request using `callback` and we can set the
-      # content-length header ourselves.
-      #
-      # There is no way to conveniently assert in an else clause because the
-      # transfer encoding could be chunked or using a newer framing mechanism.
-      if callback is undefined
-        headers['Content-Length'] = if sendingData then Buffer.byteLength(reqBody, @options.encoding) else 0
+    # If `callback` is `undefined` it means the caller isn't going to stream
+    # the body of the request using `callback` and we can set the
+    # content-length header ourselves.
+    #
+    # There is no way to conveniently assert in an else clause because the
+    # transfer encoding could be chunked or using a newer framing mechanism.
+    if callback is undefined
+      headers['Content-Length'] = if sendingData then Buffer.byteLength(reqBody, @options.encoding) else 0
 
-      if @options.auth
-        headers['Authorization'] = 'Basic ' + new Buffer(@options.auth).toString('base64');
+    if @options.auth
+      headers['Authorization'] = 'Basic ' + new Buffer(@options.auth).toString('base64');
 
-      port = @options.port ||
-        ScopedClient.defaultPort[@options.protocol] || 80
+    port = @options.port ||
+      ScopedClient.defaultPort[@options.protocol] || 80
 
-      agent = @options.agent
-      if @options.protocol == 'https:'
-        requestModule = https
-        agent = @options.httpsAgent if @options.httpsAgent
-      else
-        requestModule = http
-        agent = @options.httpAgent if @options.httpAgent
+    agent = @options.agent
+    if @options.protocol == 'https:'
+      requestModule = https
+      agent = @options.httpsAgent if @options.httpsAgent
+    else
+      requestModule = http
+      agent = @options.httpAgent if @options.httpAgent
 
-      requestOptions = {
-        port:    port
-        host:    @options.hostname
-        method:  method
-        path:    @fullPath()
-        headers: headers
-        agent:   agent
-      }
+    requestOptions = {
+      port:    port
+      host:    @options.hostname
+      method:  method
+      path:    @fullPath()
+      headers: headers
+      agent:   agent
+    }
 
-      # Extends the previous request options with all remaining options
-      extend requestOptions, @passthroughOptions
+    # Extends the previous request options with all remaining options
+    extend requestOptions, @passthroughOptions
 
-      req = requestModule.request(requestOptions)
+    req = requestModule.request(requestOptions)
 
-      if @options.timeout
-        req.setTimeout @options.timeout, () ->
-          req.abort()
+    if @options.timeout
+      req.setTimeout @options.timeout, () ->
+        req.abort()
 
-      if callback
-        req.on 'error', callback
-      req.write reqBody, @options.encoding if sendingData
-      callback null, req if callback
-    catch err
-      callback err, req if callback
-      throw err
+    if callback
+      req.on 'error', callback
+    req.write reqBody, @options.encoding if sendingData
+    callback null, req if callback
 
     (callback) =>
       if callback


### PR DESCRIPTION
Previously, if an exception was raised in #request, the function would be allowed to continue through to returning the callback. This callback would almost certainly fail. Raising here, rather than returning after calling the callback with the exception, makes more sense to me because the return value is still expected to be a function.

I ran into this when an exception was raised on the line where `req` is assigned; it went on to return the function anyway, which then failed because `req` was never defined.

cc @technicalpickles 